### PR TITLE
writer: remove max_size argument from finish

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.6,
+  "coverage_score": 91.4,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
The finish function previously enforced a maximum size and
unconditionally padded the resulting binary blob to the given size;
however, this is not desirable for all uses, and the caller can always
check the final size returned from the finish function if needed.

Fixes #4.

Signed-off-by: Daniel Verkamp <dverkamp@chromium.org>