### PR TITLE
writer: check conversions from usize to u32

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.4,
+  "coverage_score": 91.7,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
These conversions were previously unchecked casts, which would
potentially truncate large values.  In particular, large reservemap
arrays would cause overflows when calculating the size of the DT struct
in the finish function.

Fixes #6.

Signed-off-by: Daniel Verkamp <dverkamp@chromium.org>