### PR TITLE
check that mem reservations are valid

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.7,
+  "coverage_score": 87.3,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
There are two error conditions that we need to look for:
- a memory reservation entry is invalid
- there are overlapping memory reservations

To allow only valid memory reservations entries, the address and size
are no longer public, and the `FdtReserveEntry` can only be created via
a constructor that checks if the region is valid. This allows for
simplifications when checking that memory regions are not overlapping.

Fixes: https://github.com/rust-vmm/vm-fdt/issues/5