### PR TITLE
Check arithmetic operations in finish

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.8,
+  "coverage_score": 87.9,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -837,7 +837,7 @@ mod tests {
     #[test]
     #[cfg(feature = "long_running_test")]
     fn test_overflow_subtract() {
-        let overflow_size = std::u32::MAX / size_of::<FdtReserveEntry>() as u32 - 3;
+        let overflow_size = u32::MAX / size_of::<FdtReserveEntry>() as u32 - 3;
         let too_large_mem_reserve: Vec<FdtReserveEntry> = (0..overflow_size)
             .map(|i| FdtReserveEntry::new(u64::from(i) * 2, 1).unwrap())
             .collect();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -225,6 +225,8 @@ impl FdtWriter {
 
     // Rewrite the value of a big-endian u32 within data.
     fn update_u32(&mut self, offset: usize, val: u32) {
+        // Safe to use `+ 4` since we are calling this function with small values, and it's a
+        // private function.
         let data_slice = &mut self.data[offset..offset + 4];
         data_slice.copy_from_slice(&val.to_be_bytes());
     }
@@ -263,6 +265,8 @@ impl FdtWriter {
         }
 
         self.append_u32(FDT_END_NODE);
+        // This can not underflow. The above `if` makes sure there is at least one open node
+        // (node_depth >= 1).
         self.node_depth -= 1;
         self.node_ended = true;
         Ok(())

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::ffi::CString;
 use std::fmt;
-use std::mem::size_of;
+use std::mem::size_of_val;
 
 use crate::{FDT_BEGIN_NODE, FDT_END, FDT_END_NODE, FDT_MAGIC, FDT_PROP};
 
@@ -345,7 +345,7 @@ impl FdtWriter {
 
     /// Write a property containing an array of 32-bit unsigned integers.
     pub fn property_array_u32(&mut self, name: &str, cells: &[u32]) -> Result<()> {
-        let mut arr = Vec::with_capacity(cells.len() * size_of::<u32>());
+        let mut arr = Vec::with_capacity(size_of_val(cells));
         for &c in cells {
             arr.extend(&c.to_be_bytes());
         }
@@ -354,7 +354,7 @@ impl FdtWriter {
 
     /// Write a property containing an array of 64-bit unsigned integers.
     pub fn property_array_u64(&mut self, name: &str, cells: &[u64]) -> Result<()> {
-        let mut arr = Vec::with_capacity(cells.len() * size_of::<u64>());
+        let mut arr = Vec::with_capacity(size_of_val(cells));
         for &c in cells {
             arr.extend(&c.to_be_bytes());
         }
@@ -844,7 +844,7 @@ mod tests {
     #[test]
     #[cfg(feature = "long_running_test")]
     fn test_overflow_subtract() {
-        let overflow_size = u32::MAX / size_of::<FdtReserveEntry>() as u32 - 3;
+        let overflow_size = u32::MAX / std::mem::size_of::<FdtReserveEntry>() as u32 - 3;
         let too_large_mem_reserve: Vec<FdtReserveEntry> = (0..overflow_size)
             .map(|i| FdtReserveEntry::new(u64::from(i) * 2, 1).unwrap())
             .collect();


### PR DESCRIPTION
This PR addresses a nit (using u32::MAX instead of std::u32::MAX), and fixes #6.