### PR TITLE
Don't run overflow test by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,13 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
+
+[features]
+# This feature was added as a way to exclude long running tests in development.
+# `cargo test` does not run tests for all features by default. The vm-fdt
+# developer can thus choose to "hide" a long running under this feature.
+# One example of a long running test is the test that checks for overflows
+# caused by large memory allocations.
+#
+# The rust-vmm-ci will still run these tests.
+long_running_test = []

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Some questions that might help in writing this section:
   doing?
 - Is this crate used by other rust-vmm components? If yes, how?
 
+This crate defines a development feature: `long_running_test`. This feature
+SHOULD NOT be used in production as it might enable functionality that is safe
+only for development use cases.
+
 ## Examples
 
 The following is a simple example of creating a device tree with various

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 91.7,
   "exclude_path": "",
-  "crate_features": ""
+  "crate_features": "long_running_test"
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -801,6 +801,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "long_running_test")]
     fn test_overflow_subtract() {
         let overflow_size = std::u32::MAX / size_of::<FdtReserveEntry>() as u32 - 3;
         let too_large_mem_reserve: Vec<FdtReserveEntry> = (0..overflow_size)


### PR DESCRIPTION
This PR adds a feature that is used only in tests. The purpose of this feature is to "hide" the tests that take a long time to run. This is useful for development as it considerably reduces the time needed to run all tests. The ignored tests are still running as part of the CI.