### PR TITLE
update constructor of FdtWriter

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.6,
+  "coverage_score": 87.8,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }


### PR DESCRIPTION
There is no need for users to pass an empty array as memory
reservations. For the basic use case, the memory reservations are not
needed, so users should not be aware of them.

To account for this, we create 2 constructors:
- new -> takes no parameter (basic use case scenario)
- new_with_mem_reserv -> for users that want to pass memory reservations
when initializing the FdtWriter.