### PR TITLE
do not allow property before begin node

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.9,
+  "coverage_score": 87.6,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }


### PR DESCRIPTION
Properties belong to nodes, so we should check that a node is opened
before calling into property_ functions.

With this patch, fixes were also needed to existing tests.

Fixes: https://github.com/rust-vmm/vm-fdt/issues/19