### PR TITLE
Validate node and property names

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.6,
+  "coverage_score": 88.0,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,3 +72,6 @@ const FDT_BEGIN_NODE: u32 = 0x00000001;
 const FDT_END_NODE: u32 = 0x00000002;
 const FDT_PROP: u32 = 0x00000003;
 const FDT_END: u32 = 0x00000009;
+
+const NODE_NAME_MAX_LEN: usize = 31;
+const PROPERTY_NAME_MAX_LEN: usize = 31;


### PR DESCRIPTION
Add checks for the requirements in the devicetree specifications.

This does not check for any specific bus binding requirements for unit
addresses (as in "node-name@unit-address"); only the generic
requirements for all node names are enforced.

Fixes #32.

Signed-off-by: Daniel Verkamp <dverkamp@chromium.org>