### PR TITLE
Implement std::error::Error for Error type.

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -60,6 +60,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 /// Result of a FDT writer operation.
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
This allows our custom Error type to be used in places where a standard
Error is required (e.g. Box<Error>).

Signed-off-by: Daniel Verkamp <dverkamp@chromium.org>