### PR TITLE
Fix potential overflow in FdtWriter::begin_node()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+kcov_output*

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 88.0,
+  "coverage_score": 87.8,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -80,6 +80,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 const FDT_HEADER_SIZE: usize = 40;
 const FDT_VERSION: u32 = 17;
 const FDT_LAST_COMP_VERSION: u32 = 16;
+/// The same max depth as in the Linux kernel.
 const FDT_MAX_NODE_DEPTH: usize = 64;
 
 /// Interface for writing a Flattened Devicetree (FDT) and emitting a Devicetree Blob (DTB).


### PR DESCRIPTION
Add a check to make sure than node depth does not
exceed `FDT_MAX_NODE_DEPTH`.

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>