### PR TITLE
Ensure uniqueness of phandle values within FDT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 kcov_output*
+kcov_build

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.8,
+  "coverage_score": 87.4,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,27 @@
 //!
 //! # let dtb = create_fdt().unwrap();
 //! ```
+//!
+//! The [`phandle`](https://devicetree-specification.readthedocs.io/en/stable/devicetree-basics.html?#phandle)
+//! property should be set using [`FdtWriter::property_phandle`],
+//! so that the value is checked for uniqueness within the devicetree.
+//!
+//! ```rust
+//! use vm_fdt::{Error, FdtWriter};
+//!
+//! fn create_fdt() -> Result<Vec<u8>, Error> {
+//!     let mut fdt = FdtWriter::new()?;
+//!
+//!     let root_node = fdt.begin_node("root")?;
+//!     fdt.property_phandle(1)?;
+//!
+//!     fdt.end_node(root_node)?;
+//!
+//!     fdt.finish()
+//! }
+//!
+//! # let dtb = create_fdt().unwrap();
+//! ```
 
 mod writer;
 


### PR DESCRIPTION
This implementation ensures the `phandle` values' uniqueness only when the property is set using `FdtWriter::property_u32`. It's still possible to misuse phandles using raw `FdtWriter::property`, or property setters for types other than u32. However, it's such an unlikely scenario and I thought it wasn't worth the trouble to change all of the setters. 

Basic micro benchmarking of the changed `FdtWriter::property_u32` demonstrated ~60 ns slowdown if the property name is "phandle".