### PR TITLE
Adjust test coverage

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.4,
+  "coverage_score": 85.3,
   "exclude_path": "",
   "crate_features": "long_running_test"
 }


### PR DESCRIPTION
This PR includes the original one from dependabot #51
It adjusts test coverage due to updated Rust version.