### PR TITLE
Support `no_std` targets

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "test_name": "build-alloc",
+      "command": "rustup target add {target_platform}-unknown-none && env RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-none --no-default-features --features alloc",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+## Added
+- [[#68](https://github.com/rust-vmm/vm-fdt/pull/68)] Implemented `no_std`
+  support by adding a default `std` feature.
+
 ## Fixed
 - [[#69](https://github.com/rust-vmm/vm-fdt/pull/69)] Fixed
   `clippy::incorrect_partial_ord_impl_on_ord_type`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,13 @@ edition = "2018"
 repository = "https://github.com/rust-vmm/vm-fdt"
 keywords = ["fdt"]
 
+[dependencies]
+hashbrown = { version = "0.14", optional = true }
+
 [features]
+default = ["std"]
+std = []
+alloc = ["hashbrown"]
 # This feature was added as a way to exclude long running tests in development.
 # `cargo test` does not run tests for all features by default. The vm-fdt
 # developer can thus choose to "hide" a long running under this feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium OS Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 
 //! This crate provides the ability to manipulate Flattened Devicetree blobs.
@@ -80,6 +81,9 @@
 //!
 //! # let dtb = create_fdt().unwrap();
 //! ```
+
+#[macro_use]
+extern crate alloc;
 
 mod writer;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,12 +4,19 @@
 //! This module writes Flattened Devicetree blobs as defined here:
 //! <https://devicetree-specification.readthedocs.io/en/stable/flattened-format.html>
 
-use std::cmp::{Ord, Ordering};
-use std::collections::{BTreeMap, HashSet};
-use std::convert::TryInto;
-use std::ffi::CString;
-use std::fmt;
-use std::mem::size_of_val;
+use alloc::collections::BTreeMap;
+use alloc::ffi::CString;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::{Ord, Ordering};
+use core::convert::TryInto;
+use core::fmt;
+use core::mem::size_of_val;
+#[cfg(feature = "std")]
+use std::collections::HashSet;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use hashbrown::HashSet;
 
 use crate::{
     FDT_BEGIN_NODE, FDT_END, FDT_END_NODE, FDT_MAGIC, FDT_PROP, NODE_NAME_MAX_LEN,
@@ -75,10 +82,11 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// Result of a FDT writer operation.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 const FDT_HEADER_SIZE: usize = 40;
 const FDT_VERSION: u32 = 17;
@@ -308,7 +316,7 @@ impl FdtWriter {
 
     // Append `num_bytes` padding bytes (0x00).
     fn pad(&mut self, num_bytes: usize) {
-        self.data.extend(std::iter::repeat(0).take(num_bytes));
+        self.data.extend(core::iter::repeat(0).take(num_bytes));
     }
 
     // Append padding bytes (0x00) until the length of data is a multiple of `alignment`.


### PR DESCRIPTION
### Summary of the PR

This adds `no_std` support by
- adding a default `std` feature for disabling `impl Error` on `no_std`.
- adding the Hashbrown dependency for `no_std` hash sets

Hashbrown also provides the `HashSet` implementation in `std`. `std`'s `HashSet` is not in liballoc yet, though.
By default, Hashbrown uses AHash as the default hasher. AHash is much faster than `std`'s SipHash, but is not as HashDoS resistant. That seemed not relevant to me, though.

Closes https://github.com/rust-vmm/vm-fdt/issues/61

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
