### PR TITLE
fix(writer): `clippy::incorrect_partial_ord_impl_on_ord_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming Release
+
+## Fixed
+- [[#69](https://github.com/rust-vmm/vm-fdt/pull/69)] Fixed
+  `clippy::incorrect_partial_ord_impl_on_ord_type`.
+
 # v0.2.0
 
 ## Added

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -136,7 +136,7 @@ impl Ord for FdtReserveEntry {
 
 impl PartialOrd for FdtReserveEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.address.partial_cmp(&other.address)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
### Summary of the PR

```
$ cargo clippy
    Checking vm-fdt v0.2.0 (/Users/mkroening/devel/vm-fdt)
error: incorrect implementation of `partial_cmp` on an `Ord` type
   --> src/writer.rs:137:1
    |
137 | /  impl PartialOrd for FdtReserveEntry {
138 | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
    | | _____________________________________________________________-
139 | ||         self.address.partial_cmp(&other.address)
140 | ||     }
    | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
141 | |  }
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
    = note: `#[deny(clippy::incorrect_partial_ord_impl_on_ord_type)]` on by default

error: could not compile `vm-fdt` (lib) due to previous error
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
