### PR TITLE
Add `FdtWriter::property_cstring`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Added
 
-- Added `FdtWriter::property_cstring` method to allow setting `&CStr` string
+- [[#72](https://github.com/rust-vmm/vm-fdt/pull/72)] Added
+  `FdtWriter::property_cstring` method to allow setting `&CStr` string
   value directly.
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Upcoming Release
+
+## Added
+
+- Added `FdtWriter::property_cstring` method to allow setting `&CStr` string
+  value directly.
+
+## Fixed
+
 # v0.3.0
 
 ## Added

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -10,6 +10,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::cmp::{Ord, Ordering};
 use core::convert::TryInto;
+use core::ffi::CStr;
 use core::fmt;
 use core::mem::size_of_val;
 #[cfg(feature = "std")]
@@ -448,7 +449,12 @@ impl FdtWriter {
     /// Write a string property.
     pub fn property_string(&mut self, name: &str, val: &str) -> Result<()> {
         let cstr_value = CString::new(val).map_err(|_| Error::InvalidString)?;
-        self.property(name, cstr_value.to_bytes_with_nul())
+        self.property_cstring(name, &cstr_value)
+    }
+
+    /// Write a C string property.
+    pub fn property_cstring(&mut self, name: &str, val: &CStr) -> Result<()> {
+        self.property(name, val.to_bytes_with_nul())
     }
 
     /// Write a stringlist property.


### PR DESCRIPTION
### Summary of the PR

Since `FdtWriter` only accept `&str`, it does a validation to make sure it's NULL-terminated and copies the whole string in `Cstring::new()`.

This is unnecessary in some circumstances. For example, for `"bootargs"` property, linux_loader can create `CString` [1]. However, library users need to convert it into `String` [2].

This patches adds another property helper `property_cstring`, which accepts a `&CStr` value directly to eliminate the overhead.

[1] https://docs.rs/linux-loader/latest/linux_loader/cmdline/struct.Cmdline.html#method.as_cstring
[2] https://github.com/firecracker-microvm/firecracker/blob/3853362520b81efc8ce6559148d023379a5a4da4/src/vmm/src/arch/aarch64/fdt.rs#L240-L246

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
